### PR TITLE
Add 'runtime' element into 'Persimmon.Console/App.config'

### DIFF
--- a/Persimmon.Console/App.config
+++ b/Persimmon.Console/App.config
@@ -3,4 +3,12 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+    <runtime>
+      <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+        <dependentAssembly>
+          <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+          <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        </dependentAssembly>
+      </assemblyBinding>
+    </runtime>
 </configuration>


### PR DESCRIPTION
Though we have already `runtime` element in `Persimmon.Tests/app.config`, not in `Persimmon.Console/App.config`.
So I copied this element from `Persimmon.Tests/app.config` to `Persimmon.Console/App.config`.
