### PR TITLE
Update help message to change '--input' option into '--inputs'

### DIFF
--- a/Persimmon.Console/Args.fs
+++ b/Persimmon.Console/Args.fs
@@ -53,7 +53,7 @@ module Args =
 --error:<file>
     config the output file to print the error.
     print to standard error without this option.
---input:<files>
+--inputs:<files>
     comma separated input files.
 --no-progress
     disabled the report of progress.


### PR DESCRIPTION
`$ Persimmon.Console.exe` shows help messages.
The messages say the usage of `--input` option, but the argument parser doesn't handle `--input` but `--inputs`.
As `Args` type has `Inputs` field, we use `--inputs` option rather than `--input`.

This PR will fix the issue #16.
