### PR TITLE
add "trap" computation expression

### DIFF
--- a/Persimmon.Sample/Sample.fs
+++ b/Persimmon.Sample/Sample.fs
@@ -10,6 +10,15 @@ let test2 = test "failure test" {
   do! assertEquals 1 2
 }
 
+exception MyException
+
+let test3 = test "exn test" {
+  let! e = trap { raise MyException }
+  do! assertEquals "" e.Message
+  do! assertEquals typeof<MyException> (e.GetType())
+  do! assertEquals "" (e.StackTrace.Substring(0, 5))
+}
+
 let tests = [
   test "success test(list)" {
     do! assertEquals 1 1

--- a/Persimmon/Persimmon.fs
+++ b/Persimmon/Persimmon.fs
@@ -40,6 +40,18 @@ type TestBuilder(description: string) =
   member __.Run(f) = { Name = description; AssertionResult = f () }
 
 let test description = TestBuilder(description)
+
+type TrapBuilder () =
+  member __.Zero () = ()
+  member __.Delay(f: unit -> _) = f
+  member __.Run(f) =
+    try
+      f () |> ignore
+      Failure (NonEmptyList.singleton "Expect thrown exn but not")
+    with
+      e -> Success e
+
+let trap = TrapBuilder ()
  
 let inline checkWith returnValue expected actual =
   if expected = actual then Success returnValue


### PR DESCRIPTION
``` fsharp
let! e = trap { f () }
```

これは以下のコードとほぼ同じです。

``` fsharp
let! e =
  try
    f () |> ignore
    failure "..."
  with
    e -> success e
```

この記法によって、例外のテストはよりシンプルになりますが、特殊な記法は導入しすぎると学習コストも上がるため慎重になるべきだと考えています。
PersimmonのAPI設計をどうするかにかかわることになりますが、
- 提供する機能はできる限りシンプルに保ち、特殊な記法を導入しなければ実現できないものにのみ特殊な記法を許す
- どの機能を使うかはユーザの裁量に任せ、特殊な記法もそれが便利であれば提供する
- Persimmon本体はシンプルに保ち、ライブラリという形で特殊な記法を提供する
- それ以外の方針

のうち、どれを取りましょう？
