### PR TITLE
catch async exception

### DIFF
--- a/Persimmon.Tests/AsyncTest.fs
+++ b/Persimmon.Tests/AsyncTest.fs
@@ -1,0 +1,30 @@
+﻿namespace Persimmon.Tests
+
+open Persimmon
+open UseTestNameByReflection
+open Helper
+
+module AsyncTest =
+
+  let asyncReturnValue = async {
+    return 0
+  }
+
+  let ``should return value`` = test {
+    let! v = asyncRun { it asyncReturnValue }
+    do! assertEquals 0 v
+  }
+
+  exception MyException
+
+  let asyncRaiseMyException = async {
+    raise MyException
+  }
+
+  let ``should catch unhandled exception`` = test {
+    let! e =
+      match asyncRun { it asyncRaiseMyException } |> run with
+      | Error(m, es, _, _) -> TestCase.make m.Name m.Parameters (Passed (List.head es))
+      | Done(m, xs, _) -> TestCase.make m.Name m.Parameters (NotPassed (Violated "expected throw exception, but was success"))
+    do! assertEquals (typeof<MyException>) (e.GetType())
+  }

--- a/Persimmon.Tests/Persimmon.Tests.fsproj
+++ b/Persimmon.Tests/Persimmon.Tests.fsproj
@@ -63,6 +63,7 @@
     <Compile Include="Helper.fs" />
     <Compile Include="PersimmonTest.fs" />
     <Compile Include="SideEffectTest.fs" />
+    <Compile Include="AsyncTest.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/Persimmon/ComputationExpressions.fs
+++ b/Persimmon/ComputationExpressions.fs
@@ -83,3 +83,12 @@ type TrapBuilder () =
       fail "Expect thrown exn but not"
     with
       e -> pass e
+
+type AsyncRunBuilder() =
+  member __.Yield(()) = ()
+  [<CustomOperation("it")>]
+  member __.It((), a: Async<'T>) = a
+  member __.Run(a) =
+    match a |> Async.Catch |> Async.RunSynchronously with
+    | Choice1Of2 r -> TestCase.make "" [] (Passed r)
+    | Choice2Of2 e -> TestCase.makeError "" [] e 

--- a/Persimmon/Syntax.fs
+++ b/Persimmon/Syntax.fs
@@ -16,5 +16,7 @@ let skip message (target: TestCase<'T>) : TestCase<'T> =
 /// Trap the exception and convert to AssertionResult<exn>.
 let trap = TrapBuilder()
 
+let asyncRun = AsyncRunBuilder()
+
 module UseTestNameByReflection =
   let test = TestBuilder("")


### PR DESCRIPTION
非同期計算で例外が投げられた場合にテスト結果を `Error` とする機能を実装してみました。
Persimmon が .NET Framework 3.x 以下をサポートしているため、 `Task` 用の関数は用意していません。
