### PR TITLE
avoid to crash console when source raised exception in `parameterize`

### DIFF
--- a/src/Persimmon.Script/Runner.fs
+++ b/src/Persimmon.Script/Runner.fs
@@ -14,7 +14,12 @@ type ScriptTestBuilder internal (name: string) =
 
 type ScriptParameterizeBuilder() =
   member __.Delay(f) = parameterize.Delay(f)
-  member __.Run(f) = parameterize.Run(f)
+  member __.Run(f) =
+    try
+      f ()
+    with e ->
+      let e = exn("Failed to initialize `source` or `case` in `parameterize` computation expression.", e)
+      [ TestCase.makeError None [] e ]
   member __.Yield(()) = parameterize.Yield(())
   member __.Yield(xs: _ seq) = parameterize.Yield(xs)
   [<CustomOperation("case")>]

--- a/src/Persimmon/ComputationExpressions.fs
+++ b/src/Persimmon/ComputationExpressions.fs
@@ -75,7 +75,13 @@ module private Util =
 
 type ParameterizeBuilder() =
   member __.Delay(f: unit -> _) = f
-  member __.Run(f) = f ()
+  member __.Run(f) =
+    try
+      f ()
+    with e ->
+      let e = exn("Failed to initialize `source` or `case` in `parameterize` computation expression.", e)
+      TestCase.makeError None [] e :> TestObject
+      |> Seq.singleton
   member __.Yield(()) = Seq.empty
   member __.Yield(x) = Seq.singleton x
   member __.YieldFrom(xs: _ seq) = xs


### PR DESCRIPTION
fix #107 