### PR TITLE
try式を抜ける前にfinally式が実行されてしまう問題を解決する

### DIFF
--- a/src/Persimmon/ComputationExpressions.fs
+++ b/src/Persimmon/ComputationExpressions.fs
@@ -65,7 +65,16 @@ type TestBuilder private (name: string option) =
           case.Run()
         finally match box x with null -> () | _ -> x.Dispose()
     })
-  member __.TryFinally(f, g) = try f () finally g ()
+  member __.TryFinally(f, g) =
+    TestCase.init None [] (fun _ -> async {
+      return
+        try
+          let case =
+            try f ()
+            with e -> TestCase.makeError None [] e
+          case.Run()
+        finally g ()
+    })
   member __.Delay(f) = f
   member __.Run(f: unit -> TestCase<_>) =
     TestCase.init name [] (fun _ ->

--- a/tests/Persimmon.Tests/PersimmonTest.fs
+++ b/tests/Persimmon.Tests/PersimmonTest.fs
@@ -220,6 +220,16 @@ module PersimmonTest =
       do! assertEquals 1 !count
     }
 
+  let ``should not run finally expression until the end of test`` =
+    test "should not run finally expression until the end of test" {
+      let disposable = new DisposableValue()
+      try
+        do! test "empty" { return () }
+        do! disposable.Disposed |> assertEquals false
+      finally
+        (disposable :> System.IDisposable).Dispose()
+    }
+
   let ``first binding exception`` =
     let raiseTest = test "raise exception" {
       return raise TestException


### PR DESCRIPTION
## 概要
先日の use 束縛の問題 (#117) と同様の問題が try-finally にもありましたので、その修正案になります。

## その他
- Using と TryFinally の挙動が重複しているので、くくり出しを行っています。
    - Using に inline がついているので、くくりだす関数は public でなければなりません。処理の共通化を図るだけの関数を公開するのもどうかと思ったので、コードの雰囲気に反していますが TryFinally にリダイレクトしています。