### PR TITLE
アセンブリ毎にAppDomainを分けてテストを実行する

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -152,7 +152,7 @@ Target "RunTests" (fun _ ->
   !! testAssemblies
   |> Persimmon (fun p ->
     { p with
-        ToolPath = findToolInSubPath "Persimmon.Console.exe" (currentDirectory @@ "src" @@ "Persimmon.Console")
+        ToolPath = findToolInSubPath "Persimmon.Console.exe" (currentDirectory @@ "src" @@ "Persimmon.Console" @@ "bin" @@ configuration)
         Output = OutputDestination.XmlFile "TestResult.xml"
     }
   )

--- a/src/Persimmon.Console/Persimmon.Console.fsproj
+++ b/src/Persimmon.Console/Persimmon.Console.fsproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Args.fs" />
+    <Compile Include="PersimmonProxy.fs" />
     <Compile Include="Program.fs" />
     <None Include="App.config" />
     <None Include="..\..\Persimmon.snk">

--- a/src/Persimmon.Console/PersimmonProxy.fs
+++ b/src/Persimmon.Console/PersimmonProxy.fs
@@ -1,0 +1,23 @@
+﻿namespace global
+
+open System
+open System.Reflection
+open Persimmon
+open Persimmon.Runner
+
+type PersimmonProxy() =
+  inherit MarshalByRefObject()
+
+  static member Create(appDomain: AppDomain) =
+    let t = typeof<PersimmonProxy>
+    appDomain.CreateInstanceAndUnwrap(t.Assembly.FullName, t.FullName) :?> PersimmonProxy
+
+  member this.CollectAndRun(assemblyPath: string, args: Args) =
+    let asm = Assembly.LoadFrom(assemblyPath)
+    let tests = TestCollector.collectRootTestObjects [ asm ]
+    use progress = Args.progressPrinter args
+    if args.Parallel then
+      TestRunner.asyncRunAllTests progress.Print tests
+      |> Async.RunSynchronously
+    else
+      TestRunner.runAllTests progress.Print tests

--- a/tests/Persimmon.NET40.Tests/app.config
+++ b/tests/Persimmon.NET40.Tests/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.1.0" newVersion="4.4.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/Persimmon.Runner.Tests/app.config
+++ b/tests/Persimmon.Runner.Tests/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.1.0" newVersion="4.4.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/tests/Persimmon.Tests/AppDomainTest.fs
+++ b/tests/Persimmon.Tests/AppDomainTest.fs
@@ -1,0 +1,35 @@
+﻿namespace Persimmon.Tests
+
+open System
+open Persimmon
+open UseTestNameByReflection
+open Helper
+
+module AppDomainTest =
+  open System.Configuration
+
+  let ``should read value from app.config`` = test {
+    let actual = ConfigurationManager.AppSettings.["key"]
+    do! actual |> assertEquals "value"
+  }
+
+  type NonSerializableType(value: int) =
+    member this.Value = value
+
+    override this.Equals(other: obj) =
+      match other with
+      | :? NonSerializableType as other -> this.Value = other.Value
+      | _ -> false
+
+    override this.GetHashCode() = 0
+
+    override this.ToString() = "NonSerializableType"
+        
+  let nonSerializableValue = test {
+    return NonSerializableType(3)
+  }
+
+  let ``should test non-serializable type`` = test {
+    let! actual = nonSerializableValue
+    do! actual.Value |> assertEquals 3
+  }

--- a/tests/Persimmon.Tests/Helper.fs
+++ b/tests/Persimmon.Tests/Helper.fs
@@ -14,7 +14,7 @@ module Helper =
 
   let shouldPassed<'T when 'T : equality> (expected: 'T) (x: TestCase<'T>) =
     let inner = function
-      | Done (m, (Persimmon.Passed (actual: 'T), []), d) -> Done (m, (assertEquals expected actual, []), d)
+      | Done (m, (Passed (actual: 'T), []), d) -> Done (m, (assertEquals expected actual, []), d)
       | Done (m, results, d) -> Done (m, results |> NonEmptyList.map (function
         | Passed _ -> Passed ()
         | NotPassed(l, x) -> NotPassed(l, x)), d)
@@ -23,11 +23,11 @@ module Helper =
 
   let shouldNotPassed<'T> (expectedMessages: NonEmptyList<string>) (x: TestCase<'T>) =
     let inner = function
-      | Done (m, (Persimmon.Passed (actual: 'T), []), d) ->
+      | Done (m, (Passed (actual: 'T), []), d) ->
         Done (m, (fail (sprintf "Expect: Failure\nActual: %A" actual), []), d)
       | Done (m, results, d) ->
         results
-        |> NonEmptyList.map (function NotPassed(_, (Skipped x | Violated x)) -> x | Persimmon.Passed x -> sprintf "Expected is NotPased but Passed(%A)" x)
+        |> NonEmptyList.map (function NotPassed(_, (Skipped x | Violated x)) -> x | Passed x -> sprintf "Expected is NotPased but Passed(%A)" x)
         |> fun actual -> Done (m, (assertEquals expectedMessages actual, []), d)
       | Error (m, es, results, d) -> Error (m, es, results, d)
     TestCase.initForSynch x.Name x.Parameters (fun _ -> inner (run x))
@@ -39,7 +39,7 @@ module Helper =
 
   let shouldFirstRaise<'T, 'U when 'T :> exn> (x: TestCase<'U>) =
     let inner = function
-      | Done (m, (Persimmon.Passed (actual: 'U), []), d) ->
+      | Done (m, (Passed (actual: 'U), []), d) ->
         Done (m, (fail (sprintf "Expect: raise %s\nActual: %A" (typeof<'T>.Name) actual), []), d)
       | Done (m, results, d) -> Done (m, results |> NonEmptyList.map (function
         | Passed _ -> Passed ()

--- a/tests/Persimmon.Tests/Persimmon.Tests.fsproj
+++ b/tests/Persimmon.Tests/Persimmon.Tests.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="PrettyPrinterTest.fs" />
     <Compile Include="TrapTest.fs" />
     <Compile Include="RunnerTest.fs" />
+    <Compile Include="AppDomainTest.fs" />
     <None Include="..\..\Persimmon.snk">
       <Link>Persimmon.snk</Link>
     </None>
@@ -72,6 +73,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Xml" />

--- a/tests/Persimmon.Tests/app.config
+++ b/tests/Persimmon.Tests/app.config
@@ -7,8 +7,12 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.1.0" newVersion="4.4.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+
+  <appSettings>
+    <add key="key" value="value"/>
+  </appSettings>
 </configuration>


### PR DESCRIPTION
## 概要
Persimmon.Consoleで、アセンブリ毎にAppDomainを分けて実行します。

## 問題点
Persimmon.Consoleはテスト実行時にAppDomainを1つ作って実行しています。
そして、構成ファイルは`Persimmon.Console.exe.config`を参照しています。

そのため、構成ファイルに書いた設定値を読み込めない、bindingRedirectの設定を読み込めない問題があります。

この問題は、`Persimmon.Console.exe.config`に設定を書けば回避できますが、Persimmon.Consoleはリポジトリには含めずにNuGetからダウンロードするのが主流なため、良い方法ではありません。

## 変更内容
### 仕様の変更内容
* Persimmon.Consoleの引数のアセンブリ毎にAppDomainを作成するように変更しました
* 構成ファイルの参照を`Persimmon.Console.exe.config`から引数のアセンブリに変更しました
* Persimmon.ConsoleはF# 4.1を使っているが、アセンブリの構成ファイルを参照するようになったため、F# 4.1より前のバージョンを使ったテストは、構成ファイルにbindingRedirectを書く必要がある。
    （以前は`Persimmon.Console.exe.config`のbindingRedirectを使っていたため不要だった）
### ソースの変更内容
* `AssertionResult<'T>`と`TestResult<'T>`を判別共用体からクラスに変更しました
    （判別共用体だとMarshalByRefObjectを継承できないため。判別共用体自体はシリアル化可能だが、`'T`にシリアル化が不可能な型が来ると例外になった）