### PR TITLE
Category

### DIFF
--- a/docs/content/Features.fsx
+++ b/docs/content/Features.fsx
@@ -98,5 +98,27 @@ let ``some assertions test`` = [
 
 (**
 
+## Categorize tests
+
+By setting categories for test, you can filter tests to be run by category.
+
+*)
+
+let categorizedTest =
+  test "test1" {
+    do! assertEquals 2 1
+  }
+  |> category "SomeCategory" // categorize as "SomeCategory"
+
+// categorize all tests in module as "SomeCategory"
+[<Category("SomeCategory")>]
+module Module =
+  let someTest =
+    test "test2" {
+      do! assertEquals 2 1
+    }
+
+(**
+
 </div>
 *)

--- a/docs/content/Features.fsx
+++ b/docs/content/Features.fsx
@@ -3,6 +3,7 @@
 // it to define helpers that you do not want to show in the documentation.
 #I "../../bin/Persimmon"
 #I "../../bin/Persimmon.Runner"
+#r "Persimmon.dll"
 open Persimmon
 
 type Provider() =

--- a/docs/content/ja/Features.fsx
+++ b/docs/content/ja/Features.fsx
@@ -3,6 +3,7 @@
 // 見せたくない補助的なものを定義するために使います。
 #I "../../../bin/Persimmon"
 #I "../../../bin/Persimmon.Runner"
+#r "Persimmon.dll"
 open Persimmon
 
 type Provider() =

--- a/docs/content/ja/Features.fsx
+++ b/docs/content/ja/Features.fsx
@@ -98,5 +98,27 @@ let ``some assertions test`` = [
 
 (**
 
+## テストのカテゴリ化
+
+テストにカテゴリを設定すると、実行するテストをカテゴリでフィルタできます。
+
+*)
+
+let categorizedTest =
+  test "test1" {
+    do! assertEquals 2 1
+  }
+  |> category "SomeCategory" // "SomeCategory" が付与されます
+
+// このモジュール配下の全てのテストに "SomeCategory" が付与されます
+[<Category("SomeCategory")>]
+module CategorizedTests =
+  let someTest =
+    test "test2" {
+      do! assertEquals 2 1
+    }
+
+(**
+
 </div>
 *)

--- a/src/Persimmon.Console/Args.fs
+++ b/src/Persimmon.Console/Args.fs
@@ -19,6 +19,8 @@ type Args = {
   NoProgress: bool
   Parallel: bool
 
+  Filter: TestFilter
+
   Help: bool
 }
 
@@ -27,7 +29,7 @@ module Args =
   open System.Text
   open System.Diagnostics
 
-  let empty = { Inputs = []; Output = None; Error = None; Format = Normal; NoProgress = false; Parallel = false; Help = false }
+  let empty = { Inputs = []; Output = None; Error = None; Format = Normal; NoProgress = false; Parallel = false; Filter = TestFilter.allPass; Help = false }
 
   let private (|StartsWith|_|) (prefix: string) (target: string) =
     if target.StartsWith(prefix) then
@@ -59,6 +61,12 @@ module Args =
           | "xml" -> JUnitStyleXml
           | _ -> Normal
         parse { acc with Format = format } rest
+      | "category" ->
+        let includes = value.Split(',') |> Set.ofArray
+        parse { acc with Filter = { acc.Filter with IncludeCategories = acc.Filter.IncludeCategories + includes } } rest
+      | "exclude-category" ->
+        let excludes = value.Split(',') |> Set.ofArray
+        parse { acc with Filter = { acc.Filter with ExcludeCategories = acc.Filter.ExcludeCategories + excludes } } rest
       | other -> failwithf "unknown option: %s" other
   | other::rest -> parse { acc with Inputs = (FileInfo(other))::acc.Inputs } rest
 

--- a/src/Persimmon.Console/Args.fs
+++ b/src/Persimmon.Console/Args.fs
@@ -130,6 +130,10 @@ module Args =
     disabled the report of progress.
 --parallel
     run the tests asynchronous.
+--category:<names>
+    commma separated category names to run.
+--exclude-category:<names>
+    commma separated category names to not run.
 --help
     print this help message.
 ================

--- a/src/Persimmon.Console/PersimmonProxy.fs
+++ b/src/Persimmon.Console/PersimmonProxy.fs
@@ -17,7 +17,7 @@ type PersimmonProxy() =
     let tests = TestCollector.collectRootTestObjects [ asm ]
     use progress = Args.progressPrinter args
     if args.Parallel then
-      TestRunner.asyncRunAllTests progress.Print TestFilter.allPass tests
+      TestRunner.asyncRunAllTests progress.Print args.Filter tests
       |> Async.RunSynchronously
     else
-      TestRunner.runAllTests progress.Print TestFilter.allPass tests
+      TestRunner.runAllTests progress.Print args.Filter tests

--- a/src/Persimmon.Console/PersimmonProxy.fs
+++ b/src/Persimmon.Console/PersimmonProxy.fs
@@ -17,7 +17,7 @@ type PersimmonProxy() =
     let tests = TestCollector.collectRootTestObjects [ asm ]
     use progress = Args.progressPrinter args
     if args.Parallel then
-      TestRunner.asyncRunAllTests progress.Print tests
+      TestRunner.asyncRunAllTests progress.Print TestFilter.allPass tests
       |> Async.RunSynchronously
     else
-      TestRunner.runAllTests progress.Print tests
+      TestRunner.runAllTests progress.Print TestFilter.allPass tests

--- a/src/Persimmon.Runner.NET40/Persimmon.Runner.NET40.fsproj
+++ b/src/Persimmon.Runner.NET40/Persimmon.Runner.NET40.fsproj
@@ -64,6 +64,9 @@
     <Compile Include="..\Persimmon.Runner\TestCollector.fs">
       <Link>TestCollector.fs</Link>
     </Compile>
+    <Compile Include="..\Persimmon.Runner\TestFilter.fs">
+      <Link>TestFilter.fs</Link>
+    </Compile>
     <Compile Include="..\Persimmon.Runner\TestRunner.fs">
       <Link>TestRunner.fs</Link>
     </Compile>

--- a/src/Persimmon.Runner.NETCore/Persimmon.Runner.NETCore.fsproj
+++ b/src/Persimmon.Runner.NETCore/Persimmon.Runner.NETCore.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="..\Persimmon.Runner\Printer.fs" />
     <Compile Include="..\Persimmon.Runner\Reporter.fs" />
     <Compile Include="..\Persimmon.Runner\TestCollector.fs" />
+    <Compile Include="..\Persimmon.Runner\TestFilter.fs" />
     <Compile Include="..\Persimmon.Runner\TestRunner.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Persimmon.Runner/Persimmon.Runner.fsproj
+++ b/src/Persimmon.Runner/Persimmon.Runner.fsproj
@@ -62,6 +62,7 @@
     <Compile Include="Printer.fs" />
     <Compile Include="Reporter.fs" />
     <Compile Include="TestCollector.fs" />
+    <Compile Include="TestFilter.fs" />
     <Compile Include="TestRunner.fs" />
     <None Include="..\..\Persimmon.snk">
       <Link>Persimmon.snk</Link>

--- a/src/Persimmon.Runner/TestFilter.fs
+++ b/src/Persimmon.Runner/TestFilter.fs
@@ -19,9 +19,17 @@ module TestFilter =
 
   let private categories (t: TestMetadata) = Set.ofArray t.Categories
 
+  let private testCaseFilter (pred: TestCase -> bool) = fun (t: TestMetadata) ->
+    match t with
+    | :? TestCase as tc -> pred tc
+    | _ -> true
+
   let make (filter: TestFilter) : TestMetadata -> bool =
     match filter.IncludeCategories.IsEmpty, filter.ExcludeCategories.IsEmpty with
     | true, true -> fun _ -> true
-    | false, false -> fun t -> let categories = categories t in (includeCategoryFilter filter.IncludeCategories categories && excludeCategoryFilter filter.ExcludeCategories categories)
-    | false, true -> fun t -> let categories = categories t in (includeCategoryFilter filter.IncludeCategories categories)
-    | true, false -> fun t -> let categories = categories t in (excludeCategoryFilter filter.ExcludeCategories categories)
+    | false, false ->
+      testCaseFilter <| fun tc -> let categories = categories tc in (includeCategoryFilter filter.IncludeCategories categories && excludeCategoryFilter filter.ExcludeCategories categories)
+    | false, true ->
+      testCaseFilter <| fun tc -> let categories = categories tc in (includeCategoryFilter filter.IncludeCategories categories)
+    | true, false ->
+      testCaseFilter <| fun tc -> let categories = categories tc in (excludeCategoryFilter filter.ExcludeCategories categories)

--- a/src/Persimmon.Runner/TestFilter.fs
+++ b/src/Persimmon.Runner/TestFilter.fs
@@ -1,0 +1,27 @@
+﻿namespace Persimmon.Runner
+
+type TestFilter = {
+  IncludeCategories: Set<string>
+  ExcludeCategories: Set<string>
+}
+
+[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
+module TestFilter =
+  open Persimmon
+
+  let allPass = { IncludeCategories = Set.empty; ExcludeCategories = Set.empty }
+
+  let private excludeCategoryFilter (excludes: Set<string>) (categories: Set<string>) =
+    Set.intersect excludes categories |> Set.isEmpty
+
+  let private includeCategoryFilter (includes: Set<string>) (categories: Set<string>) =
+    Set.intersect includes categories = includes
+
+  let private categories (t: TestMetadata) = Set.ofArray t.Categories
+
+  let make (filter: TestFilter) : TestMetadata -> bool =
+    match filter.IncludeCategories.IsEmpty, filter.ExcludeCategories.IsEmpty with
+    | true, true -> fun _ -> true
+    | false, false -> fun t -> let categories = categories t in (includeCategoryFilter filter.IncludeCategories categories && excludeCategoryFilter filter.ExcludeCategories categories)
+    | false, true -> fun t -> let categories = categories t in (includeCategoryFilter filter.IncludeCategories categories)
+    | true, false -> fun t -> let categories = categories t in (excludeCategoryFilter filter.ExcludeCategories categories)

--- a/src/Persimmon.Runner/TestRunner.fs
+++ b/src/Persimmon.Runner/TestRunner.fs
@@ -6,11 +6,13 @@ open Persimmon.Internals
 /// Run all tests synchronously.
 /// TODO: Omit all synch caller.
 //[<Obsolete>]
-let runAllTests progress (tests: #TestMetadata seq) =
+let runAllTests progress filter (tests: #TestMetadata seq) =
   let runner = TestRunner()
-  runner.RunSynchronouslyAllTests(progress, tests)
+  let filter = TestFilter.make filter
+  runner.RunSynchronouslyAllTests(progress, filter, tests)
 
 /// Run all tests.
-let asyncRunAllTests progress (tests: #TestMetadata seq) =
+let asyncRunAllTests progress filter (tests: #TestMetadata seq) =
   let runner = TestRunner()
-  runner.AsyncRunAllTests(progress, tests)
+  let filter = TestFilter.make filter
+  runner.AsyncRunAllTests(progress, filter, tests)

--- a/src/Persimmon/Internals/TestCollector.fs
+++ b/src/Persimmon/Internals/TestCollector.fs
@@ -139,12 +139,6 @@ module internal TestCollectorImpl =
     |> Seq.collect (fun attr -> (attr :?> CategoryAttribute).Categories)
     |> Seq.toArray
 
-  let rec private addCategories (categories: string[]) (target: TestMetadata) =
-    target.AddCategories(categories)
-    match target with
-    | :? Context as context -> context.Children |> Array.iter (addCategories categories)
-    | _ -> ()
-
   /// Retreive test object via target type, and traverse.
   let rec collectTests (typ: Type) =
     seq {
@@ -191,12 +185,11 @@ module internal TestCollectorImpl =
 #endif
     }
   and collectTestsAsContext (typ: Type) =
-    let categories = collectCategories typ
     let tests = collectTests typ |> Seq.toArray
     if Array.isEmpty tests then
       None
     else
-      do tests |> Array.iter (addCategories categories)
+      let categories = collectCategories typ
       Some (Context(typ.Name, categories, tests) :> TestMetadata)
 
   /// Collect test cases from assembly

--- a/src/Persimmon/Syntax.fs
+++ b/src/Persimmon/Syntax.fs
@@ -4,7 +4,7 @@ module Persimmon.Syntax
 open System.Diagnostics
 
 /// Create the context.
-let context name children = Context(name, children)
+let context name children = Context(name, [], children)
 
 /// Create the test case.
 let test (name: string) = TestBuilder(name)
@@ -13,7 +13,7 @@ let parameterize = ParameterizeBuilder()
 
 /// Skip the test case.
 let skip message (target: TestCase<'T>) : TestCase<'T> =
-  TestCase.makeDone target.Name target.Parameters (NotPassed(None, Skipped message))
+  TestCase.makeDone target.Name target.Categories target.Parameters (NotPassed(None, Skipped message))
 
 let timeout time (target: TestCase<'T>): TestCase<'T> =
   let body _ = async {
@@ -26,7 +26,16 @@ let timeout time (target: TestCase<'T>): TestCase<'T> =
         watch.Stop()
         Error(target, [|e|], [], watch.Elapsed)
   }
-  TestCase<'T>(target.Name, target.Parameters, body)
+  TestCase<'T>(target.Name, target.Categories, target.Parameters, body)
+
+/// Add the categories to the test case
+let categories categories (target: TestCase<'T>) : TestCase<'T> =
+  let newCategories = Seq.append target.Categories categories
+  let body = fun _ -> target.AsyncRun()
+  TestCase<'T>(target.Name, newCategories, target.Parameters, body)
+
+/// Add the category to the test case
+let category category (target: TestCase<'T>) : TestCase<'T> = categories [ category ] target
 
 /// Trap the exception and convert to AssertionResult<exn>.
 let trap = TrapBuilder()

--- a/src/Persimmon/TestCase.fs
+++ b/src/Persimmon/TestCase.fs
@@ -19,21 +19,22 @@ type TestCaseType<'T> =
 module TestCase =
 
   /// Create test case manually.
-  let init name parameters (asyncBody: TestCase<_> -> Async<TestResult<_>>) =
-    TestCase<_>(name, parameters, asyncBody)
+  let init name categories parameters (asyncBody: TestCase<_> -> Async<TestResult<_>>) =
+    TestCase<_>(name, categories, parameters, asyncBody)
 
   /// Create always completion test case.
-  let makeDone name parameters x =
-    TestCase<_>(name, parameters, fun testCase -> async { return Done (testCase, NonEmptyList.singleton x, TimeSpan.Zero) })
+  let makeDone name categories parameters x =
+    TestCase<_>(name, categories, parameters, fun testCase -> async { return Done (testCase, NonEmptyList.singleton x, TimeSpan.Zero) })
 
   /// Create always error test case.
-  let makeError name parameters exn =
-    TestCase<_>(name, parameters, fun testCase -> async { return Error (testCase, [|exn|], [], TimeSpan.Zero) })
+  let makeError name categories parameters exn =
+    TestCase<_>(name, categories, parameters, fun testCase -> async { return Error (testCase, [|exn|], [], TimeSpan.Zero) })
 
   /// Add not passed test after test.
   let addNotPassed line notPassedCause (x: TestCase<_>) =
     TestCase<_>(
       x.Name,
+      x.Categories,
       x.Parameters,
       fun _ -> async {
         let! result = x.AsyncRun()
@@ -134,6 +135,6 @@ module TestCase =
   let combine (x: TestCaseType<'T>) (rest: 'T -> TestCase<'U>) =
     match x with
     | NoValueTest x ->
-      TestCase<'U>(x.Name, x.Parameters, fun _ -> runNoValueTest x rest)
+      TestCase<'U>(x.Name, x.Categories, x.Parameters, fun _ -> runNoValueTest x rest)
     | HasValueTest x ->
-      TestCase<'U>(x.Name, x.Parameters, fun _ -> runHasValueTest x rest)
+      TestCase<'U>(x.Name, x.Categories, x.Parameters, fun _ -> runHasValueTest x rest)

--- a/src/Persimmon/TestResult.fs
+++ b/src/Persimmon/TestResult.fs
@@ -11,7 +11,7 @@ module TestResult =
     return InvalidOperationException() |> raise
   }
   let private endMarkerTestCase =
-    new TestCase<unit>(Some "endMarker", [], endMarkerTestBody) :> TestCase
+    new TestCase<unit>(Some "endMarker", [], [], endMarkerTestBody) :> TestCase
   let private endMarkerResult : AssertionResult<unit> = NotPassed (None, Skipped "endMarker")
   let private endMarkerResults = [endMarkerResult] |> NonEmptyList.ofSeq
 

--- a/src/Persimmon/Types.fs
+++ b/src/Persimmon/Types.fs
@@ -122,7 +122,7 @@ type TestMetadata internal(name: string option, categories: string seq) =
   [<DefaultValue>]
   val mutable private index : int option
 
-  let categories = ResizeArray(categories)
+  let categories = Seq.toArray categories
 
   /// The test name. It doesn't contain the parameters.
   /// If not set, fallback to raw symbol name.
@@ -142,7 +142,7 @@ type TestMetadata internal(name: string option, categories: string seq) =
   member this.Index = this.index
 
   /// Metadata categories.
-  member this.Categories = categories.ToArray()
+  member this.Categories = this.InternalCategories |> Seq.toArray
 
   /// For internal use only.
   member internal this.RawSymbolName = this.symbolName
@@ -187,7 +187,13 @@ type TestMetadata internal(name: string option, categories: string seq) =
     | _ -> ()
 
   /// For internal use only.
-  member internal this.AddCategories(xs: string seq) = categories.AddRange(xs)
+  member internal this.InternalCategories =
+    seq {
+      yield! categories
+      match this.parent with
+      | Some p -> yield! p.InternalCategories
+      | None -> ()
+    }
 
 [<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
 module private TestMetadata =

--- a/tests/Persimmon.Runner.Tests/FormatterTest.fs
+++ b/tests/Persimmon.Runner.Tests/FormatterTest.fs
@@ -42,16 +42,16 @@ module Xml =
   let ``should validate result xml`` = parameterize {
     source [
       [
-        Context("FormatterTest", [TestCase.makeDone (Some "testcase0") [] (Passed ())])
+        Context("FormatterTest", [], [TestCase.makeDone (Some "testcase0") [] [] (Passed ())])
       ]
       [
-        Context("FormatterTest", [TestCase.makeDone (Some "testcase0") [] (NotPassed(None, Skipped "skip test"))])
+        Context("FormatterTest", [], [TestCase.makeDone (Some "testcase0") [] [] (NotPassed(None, Skipped "skip test"))])
       ]
       [
-        Context("FormatterTest", [TestCase.makeDone (Some "testcase0") [] (NotPassed(None, Violated "fail test"))])
+        Context("FormatterTest", [], [TestCase.makeDone (Some "testcase0") [] [] (NotPassed(None, Violated "fail test"))])
       ]
       [
-        Context("FormatterTest", [TestCase.makeError (Some "testcase0") [] (exn("test"))])
+        Context("FormatterTest", [], [TestCase.makeError (Some "testcase0") [] [] (exn("test"))])
       ]
     ]
     run validate

--- a/tests/Persimmon.Runner.Tests/FormatterTest.fs
+++ b/tests/Persimmon.Runner.Tests/FormatterTest.fs
@@ -24,7 +24,7 @@ module Xml =
     let filePath = Guid.NewGuid().ToString() |> outFile
     let writer = new StreamWriter(filePath)
     formatter.Format(
-      Internals.TestRunnerImpl.runTests ignore Internals.TestRunnerImpl.asyncSequential tests |> Async.RunSynchronously
+      Internals.TestRunnerImpl.runTests ignore Internals.TestRunnerImpl.asyncSequential (fun _ -> true) tests |> Async.RunSynchronously
     ).WriteTo(writer)
     writer.Dispose()
     let doc = XDocument.Load(filePath)

--- a/tests/Persimmon.Runner.Tests/Persimmon.Runner.Tests.fsproj
+++ b/tests/Persimmon.Runner.Tests/Persimmon.Runner.Tests.fsproj
@@ -58,6 +58,7 @@
     <None Include="paket.references" />
     <Content Include="app.config" />
     <Compile Include="FormatterTest.fs" />
+    <Compile Include="TestFilterTest.fs" />
     <None Include="..\..\Persimmon.snk">
       <Link>Persimmon.snk</Link>
     </None>

--- a/tests/Persimmon.Runner.Tests/TestFilterTest.fs
+++ b/tests/Persimmon.Runner.Tests/TestFilterTest.fs
@@ -1,0 +1,38 @@
+﻿module Persimmon.Runner.Tests.TestFilterTest
+
+open Persimmon
+open UseTestNameByReflection
+open Persimmon.Runner
+
+let ``should filter testcase`` = parameterize {
+  source [
+    [ "A" ], [], [ "A" ], true
+    [ "A" ], [], [ "B" ], false
+    [ "A" ], [], [], false
+
+    [ "A"; "B" ], [], [ "A"; "B" ], true
+    [ "A"; "B" ], [], [ "A"; ], false
+
+    [], [ "A" ], [ "A"; "B" ], false
+    [], [ "A" ], [ "B" ], true
+    [], [ "A" ], [], true
+
+    [], [ "A"; "B" ], [ "A" ], false
+    [], [ "A"; "B" ], [ "B" ], false
+    [], [ "A"; "B" ], [ "C" ], true
+
+    [ "A" ], [ "B" ], [ "A" ], true
+    [ "A" ], [ "B" ], [ "A"; "C" ], true
+    [ "A" ], [ "B" ], [ "A"; "B"; "C" ], false
+    [ "A" ], [ "B" ], [ "C" ], false
+
+    [], [], [], true
+    [], [], [ "A" ], true
+  ]
+  run (fun (includes, excludes, categories, expected) -> test {
+    let filter = TestFilter.make { IncludeCategories = Set.ofList includes; ExcludeCategories = Set.ofList excludes }
+    let testCase = TestCase.makeDone None (Seq.ofList categories) [] (Passed ())
+    let actual = filter testCase
+    do! actual |> assertEquals expected
+  })
+}

--- a/tests/Persimmon.Tests/AsyncTest.fs
+++ b/tests/Persimmon.Tests/AsyncTest.fs
@@ -24,7 +24,7 @@ module AsyncTest =
   let ``should catch unhandled exception`` = test {
     let! e =
       match asyncRun { it asyncRaiseMyException } |> run with
-      | Error(m, es, _, _) -> TestCase.makeDone m.Name m.Parameters (Passed (es.[0]))
-      | Done(m, xs, _) -> TestCase.makeDone m.Name m.Parameters (NotPassed(None, Violated "expected throw exception, but was success"))
+      | Error(m, es, _, _) -> TestCase.makeDone m.Name m.Categories m.Parameters (Passed (es.[0]))
+      | Done(m, xs, _) -> TestCase.makeDone m.Name m.Categories m.Parameters (NotPassed(None, Violated "expected throw exception, but was success"))
     do! assertEquals (typeof<MyException>) (e.GetType())
   }

--- a/tests/Persimmon.Tests/Helper.fs
+++ b/tests/Persimmon.Tests/Helper.fs
@@ -37,7 +37,7 @@ module Helper =
 
   let shouldEqualErrorCount expected xs =
     use printer = new Printer<_>(new StringWriter(), Formatter.ProgressFormatter.dot)
-    (xs |> TestRunner.runAllTests printer.Print).Errors
+    (xs |> TestRunner.runAllTests printer.Print TestFilter.allPass).Errors
     |> assertEquals expected
 
   let shouldFirstRaise<'T, 'U when 'T :> exn> (x: TestCase<'U>) =

--- a/tests/Persimmon.Tests/Helper.fs
+++ b/tests/Persimmon.Tests/Helper.fs
@@ -13,7 +13,7 @@ module Helper =
   let run (x: TestCase<_>) = x.AsyncRun() |> Async.RunSynchronously
 
   let private init (x: TestCase<'T>) f =
-    TestCase.init x.Name x.Parameters (fun _ -> async { return f (run x) })
+    TestCase.init x.Name x.Categories x.Parameters (fun _ -> async { return f (run x) })
 
   let shouldPassed<'T when 'T : equality> (expected: 'T) (x: TestCase<'T>) =
     let inner = function

--- a/tests/Persimmon.Tests/MetadataTest.fs
+++ b/tests/Persimmon.Tests/MetadataTest.fs
@@ -12,9 +12,9 @@ module MetadataTest =
 
   let ``should output full name`` = parameterize {
     source [
-      TestCase.init (Some "test") [] dummyRun, "test"
-      TestCase.init (Some "test") [ (typeof<int>, box 1) ] dummyRun, "test(1)"
-      TestCase.init (Some "test") [ (typeof<int>, box 1); (typeof<string>, box "param") ] dummyRun, """test(1, "param")"""
+      TestCase.init (Some "test") [] [] dummyRun, "test"
+      TestCase.init (Some "test") [] [ (typeof<int>, box 1) ] dummyRun, "test(1)"
+      TestCase.init (Some "test") [] [ (typeof<int>, box 1); (typeof<string>, box "param") ] dummyRun, """test(1, "param")"""
     ]
     run (fun (metadata, expected) -> test {
       do! assertEquals expected <| sprintf "%A" metadata

--- a/tests/Persimmon.Tests/Persimmon.Tests.fsproj
+++ b/tests/Persimmon.Tests/Persimmon.Tests.fsproj
@@ -67,6 +67,7 @@
     <Compile Include="RunnerTest.fs" />
     <Compile Include="AppDomainTest.fs" />
     <Compile Include="ResultNodeTest.fs" />
+    <Compile Include="TestCollectorTest.fs" />
     <None Include="..\..\Persimmon.snk">
       <Link>Persimmon.snk</Link>
     </None>

--- a/tests/Persimmon.Tests/RunnerTest.fs
+++ b/tests/Persimmon.Tests/RunnerTest.fs
@@ -6,10 +6,10 @@ open Persimmon.Tests
 
 let ``count errors`` = parameterize {
   source [
-    (TestCase.makeDone None Seq.empty (Passed ()), 0)
-    (TestCase.makeDone None Seq.empty (NotPassed(None, Violated "")), 1)
-    (TestCase.makeError None Seq.empty (exn()), 1)
-    (TestCase.makeError None Seq.empty (exn()) |> TestCase.addNotPassed None (Violated ""), 1)
+    (TestCase.makeDone None Seq.empty Seq.empty (Passed ()), 0)
+    (TestCase.makeDone None Seq.empty Seq.empty (NotPassed(None, Violated "")), 1)
+    (TestCase.makeError None Seq.empty Seq.empty (exn()), 1)
+    (TestCase.makeError None Seq.empty Seq.empty (exn()) |> TestCase.addNotPassed None (Violated ""), 1)
   ]
   run (fun (case, expected) -> test {
     do!

--- a/tests/Persimmon.Tests/TestCollectorTest.fs
+++ b/tests/Persimmon.Tests/TestCollectorTest.fs
@@ -1,0 +1,73 @@
+﻿namespace Persimmon.Tests
+
+open System
+open Persimmon
+open Persimmon.ActivePatterns
+open UseTestNameByReflection
+open Helper
+
+module TestCollectorTest =
+  type private Dummy() = class end
+
+  let ``should read category`` = parameterize {
+    source [
+      "", "noCategory", [||]
+      "", "oneCategory", [| "A" |]
+      "", "manyCategory", [| "A"; "B" |]
+      "", "immutable", [| "A"; "C" |]
+      "", "parameterizeTests(1)[0]", [| "A" |]
+      "+WithCategoryAttribute", "noCategory", [| "ModuleCategory" |]
+      "+WithCategoryAttribute", "oneCategory", [| "a"; "ModuleCategory" |]
+      "+WithCategoryAttribute", "immutable", [| "a"; "c"; "ModuleCategory" |]
+      "+WithCategoryAttribute", "parameterizeTests(1)[0]", [| "a"; "ModuleCategory" |]
+      "+WithCategoryAttribute+NestedModule", "test1", [| "ModuleCategory" |]
+      "+WithCategoryAttribute+NestedModule2", "test1", [| "ModuleCategory"; "ModuleCategory2" |]
+      "+Multiple", "test1", [| "A"; "B"; "C" |]
+    ]
+    run (fun (moduleName, testName, expected) -> test {
+      let fullModuleName = "Persimmon.Tests.TestCollectorTest+ForCategoryTest" + moduleName
+      let moduleType = Internals.Runtime.getModule<Dummy> fullModuleName
+      let tests =
+        Internals.TestCollectorImpl.collectTests moduleType
+        |> Seq.collect Internals.TestCollectorImpl.flattenTestCase
+      let actual = tests |> Seq.find (fun x -> x.DisplayName = testName)
+      do! (Array.sort actual.Categories) |> assertEquals (Array.sort expected)
+    })
+  }
+
+  module ForCategoryTest =
+    // These are dummy test for reading category test.
+    let noCategory = test { do! pass() }
+    let oneCategory = test { do! pass() } |> category "A"
+    let manyCategory = test { do! pass() } |> category "A" |> category "B"
+
+    let immutable = oneCategory |> category "C"
+
+    let parameterizeTests = parameterize {
+      source [ 1..2 ]
+      run (fun n -> test { do! pass() } |> category "A")
+    }
+
+    [<Category("ModuleCategory")>]
+    module WithCategoryAttribute =
+      let noCategory = test { do! pass() }
+      let oneCategory = test { do! pass() } |> category "a"
+      let manyCategory = test { do! pass() } |> category "a" |> category "b"
+
+      let immutable = oneCategory |> category "c"
+
+      let parameterizeTests = parameterize {
+        source [ 1..2 ]
+        run (fun n -> test { do! pass() } |> category "a")
+      }
+
+      module NestedModule =
+        let test1 = test { do! pass() }
+
+      [<Category("ModuleCategory2")>]
+      module NestedModule2 =
+        let test1 = test { do! pass() }
+
+    [<Category("A", "B"); Category("C")>]
+    module Multiple =
+      let test1 = test { do! pass() }


### PR DESCRIPTION
#26 の実装です

カテゴリによるフィルタを `TestMetadata -> bool` という型で表現しました。この関数を`Internals.TestRunner`の各メソッドに渡します。

フィルタ関数を生成するユーティリティが`Persimmon.Runner.TestFilter`です。
将来カテゴリ以外でもフィルタできるようになってます。

タスク
- [x] 実装
- [x] テスト
- [x] ドキュメント