### PR TITLE
fix #135

### DIFF
--- a/src/Persimmon/ResultNode.fs
+++ b/src/Persimmon/ResultNode.fs
@@ -35,7 +35,7 @@ module ResultNode =
           yield! xs |> Seq.map (fun x -> indent + (String.replicate no.Length " ") + x)
       })
 
-  let private exnsToStrs indent (exns: exn seq) =
+  let private exnsToStrs indent (exns: ExceptionWrapper seq) =
     exns
     |> Seq.mapi (fun i exn -> (i + 1, exn))
     |> Seq.collect (fun (i, exn) ->

--- a/src/Persimmon/Syntax.fs
+++ b/src/Persimmon/Syntax.fs
@@ -24,7 +24,7 @@ let timeout time (target: TestCase<'T>): TestCase<'T> =
       with
       | :? System.TimeoutException as e ->
         watch.Stop()
-        Error(target, [|e|], [], watch.Elapsed)
+        Error(target, [| ExceptionWrapper(e) |], [], watch.Elapsed)
   }
   TestCase<'T>(target.Name, target.Categories, target.Parameters, body)
 

--- a/src/Persimmon/TestCase.fs
+++ b/src/Persimmon/TestCase.fs
@@ -28,7 +28,7 @@ module TestCase =
 
   /// Create always error test case.
   let makeError name categories parameters exn =
-    TestCase<_>(name, categories, parameters, fun testCase -> async { return Error (testCase, [|exn|], [], TimeSpan.Zero) })
+    TestCase<_>(name, categories, parameters, fun testCase -> async { return Error (testCase, [| exn |], [], TimeSpan.Zero) })
 
   /// Add not passed test after test.
   let addNotPassed line notPassedCause (x: TestCase<_>) =
@@ -54,7 +54,7 @@ module TestCase =
         finally watch.Stop()
       with e ->
         watch.Stop()
-        return Error (testCase, [|e|], [], duration + watch.Elapsed)
+        return Error (testCase, [| ExceptionWrapper(e) |], [], duration + watch.Elapsed)
     | Done (testCase, assertionResults, duration) ->
       // If the TestCase does not have any values,
       // even if the assertion is not passed,
@@ -78,7 +78,7 @@ module TestCase =
             |> TestResult.addDuration duration
       with e ->
         watch.Stop()
-        return Error (testCase, [|e|], notPassed, duration + watch.Elapsed)
+        return Error (testCase, [| ExceptionWrapper(e) |], notPassed, duration + watch.Elapsed)
     | Error (testCase, es, results, duration) ->
       // If the TestCase does not have any values,
       // even if the assertion is not passed,
@@ -100,7 +100,7 @@ module TestCase =
            |> TestResult.addExceptions es
       with e ->
         watch.Stop()
-        return Error (testCase, Array.append [|e|] es, results, duration + watch.Elapsed)
+        return Error (testCase, Array.append [| ExceptionWrapper(e) |] es, results, duration + watch.Elapsed)
   }
 
   let private runHasValueTest (x: TestCase<'T>) (rest: 'T -> TestCase<'U>) = async {
@@ -114,7 +114,7 @@ module TestCase =
         return result
       with e ->
         watch.Stop()
-        return Error (testCase, [|e|], [], duration + watch.Elapsed)
+        return Error (testCase, [| ExceptionWrapper(e) |], [], duration + watch.Elapsed)
     | Done (testCase, assertionResults, duration) ->
       // If the TestCase has some values,
       // the test is not continuable.

--- a/src/Persimmon/TestResult.fs
+++ b/src/Persimmon/TestResult.fs
@@ -35,7 +35,7 @@ module TestResult =
     | Done (testCase, results, d) -> Done (testCase, results, d + x)
     | Error (testCase, es, results, ts) -> Error (testCase, es, results, ts + x)
 
-  let addExceptions (es: exn []) = function
+  let addExceptions (es: ExceptionWrapper []) = function
     | Done (testCase, (Passed _, []), d) -> Error(testCase, es, [], d)
     | Done (testCase, results, d) ->
       let results =

--- a/src/Persimmon/Types.fs
+++ b/src/Persimmon/Types.fs
@@ -235,7 +235,7 @@ module private TestMetadata =
 
 /// Wrap exception for cross AppDomain.
 [<Sealed>]
-type ExceptionWrapper internal (ex: exn) =
+type ExceptionWrapper (ex: exn) =
   inherit MarshalByRefObject()
 
   /// Get full type name of wrapped exception.

--- a/tests/Persimmon.Runner.Tests/FormatterTest.fs
+++ b/tests/Persimmon.Runner.Tests/FormatterTest.fs
@@ -51,7 +51,7 @@ module Xml =
         Context("FormatterTest", [], [TestCase.makeDone (Some "testcase0") [] [] (NotPassed(None, Violated "fail test"))])
       ]
       [
-        Context("FormatterTest", [], [TestCase.makeError (Some "testcase0") [] [] (exn("test"))])
+        Context("FormatterTest", [], [TestCase.makeError (Some "testcase0") [] [] (ExceptionWrapper(exn("test")))])
       ]
     ]
     run validate

--- a/tests/Persimmon.Tests/AsyncTest.fs
+++ b/tests/Persimmon.Tests/AsyncTest.fs
@@ -26,5 +26,5 @@ module AsyncTest =
       match asyncRun { it asyncRaiseMyException } |> run with
       | Error(m, es, _, _) -> TestCase.makeDone m.Name m.Categories m.Parameters (Passed (es.[0]))
       | Done(m, xs, _) -> TestCase.makeDone m.Name m.Categories m.Parameters (NotPassed(None, Violated "expected throw exception, but was success"))
-    do! assertEquals (typeof<MyException>) (e.GetType())
+    do! assertEquals (typeof<MyException>.FullName) (e.FullTypeName)
   }

--- a/tests/Persimmon.Tests/Helper.fs
+++ b/tests/Persimmon.Tests/Helper.fs
@@ -49,5 +49,8 @@ module Helper =
         | NotPassed(l, x) -> NotPassed(l, x)), d)
       | Error (m, [||], results, d) ->
         Done (m, (fail (sprintf "Expect: raise %s\nActual: not raise exception" (typeof<'T>.Name)), []), d)
-      | Error (m, xs, results, d) -> Done (m, (assertEquals typeof<'T> (xs.[0].GetType()), []), d)
+      | Error (m, xs, results, d) ->
+        let expectedTypeName = typeof<'T>.FullName
+        let actualTypeName = xs.[0].FullTypeName
+        Done (m, (assertEquals expectedTypeName actualTypeName, []), d)
     init x inner

--- a/tests/Persimmon.Tests/PersimmonTest.fs
+++ b/tests/Persimmon.Tests/PersimmonTest.fs
@@ -241,3 +241,10 @@ module PersimmonTest =
     test "first binding exception" {
       do! shouldFirstRaise<TestException, unit> bindingTest
     }
+
+  // bug #135
+  let ``can fail with exception`` =
+    test "can fail with exception" {
+      do raise TestException
+      do! fail "fail test"
+    }

--- a/tests/Persimmon.Tests/PersimmonTest.fs
+++ b/tests/Persimmon.Tests/PersimmonTest.fs
@@ -248,3 +248,4 @@ module PersimmonTest =
       do raise TestException
       do! fail "fail test"
     }
+    |> skip "skip exception test"

--- a/tests/Persimmon.Tests/RunnerTest.fs
+++ b/tests/Persimmon.Tests/RunnerTest.fs
@@ -8,8 +8,8 @@ let ``count errors`` = parameterize {
   source [
     (TestCase.makeDone None Seq.empty Seq.empty (Passed ()), 0)
     (TestCase.makeDone None Seq.empty Seq.empty (NotPassed(None, Violated "")), 1)
-    (TestCase.makeError None Seq.empty Seq.empty (exn()), 1)
-    (TestCase.makeError None Seq.empty Seq.empty (exn()) |> TestCase.addNotPassed None (Violated ""), 1)
+    (TestCase.makeError None Seq.empty Seq.empty (ExceptionWrapper(exn())), 1)
+    (TestCase.makeError None Seq.empty Seq.empty (ExceptionWrapper(exn())) |> TestCase.addNotPassed None (Violated ""), 1)
   ]
   run (fun (case, expected) -> test {
     do!


### PR DESCRIPTION
対応前

```
!!! FATAL Error !!!
System.Runtime.Serialization.SerializationException: アセンブリ 'Persimmon.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=3fbdeb1b8d22ec83' が見つかりません。

Server stack trace:
   場所 System.Runtime.Serialization.Formatters.Binary.BinaryAssemblyInfo.GetAssembly()
   場所 System.Runtime.Serialization.Formatters.Binary.ObjectReader.GetType(BinaryAssemblyInfo assemblyInfo, String name)
   ...
```

対応後

```
begin Persimmon.Tests.PersimmonTest
 FATAL ERROR: can fail with exception
 ---------------------------- exceptions -----------------------------
 1. Persimmon.Tests.PersimmonTest+TestException: 種類 'Persimmon.Tests.PersimmonTest+TestException' の例外がスローされました。
       場所 Microsoft.FSharp.Core.Operators.Raise[T](Exception exn)
       場所 Persimmon.Tests.PersimmonTest.can fail with exception@248.Invoke(Unit unitVar) 場所 D:\repos\Persimmon\tests\Persimmon.Tests\PersimmonTest.fs:行 248
       場所 <StartupCode$Persimmon>.$ComputationExpressions.Run@94.Invoke(TestCase`1 _arg4) 場所 D:\repos\Persimmon\src\Persimmon\ComputationExpressions.fs:行 96
end Persimmon.Tests.PersimmonTest
```