### PR TITLE
Disable generating assembly info.

### DIFF
--- a/src/Persimmon.Console/Persimmon.Console.fsproj
+++ b/src/Persimmon.Console/Persimmon.Console.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net462</TargetFramework>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/Persimmon.Runner/Persimmon.Runner.fsproj
+++ b/src/Persimmon.Runner/Persimmon.Runner.fsproj
@@ -7,6 +7,7 @@
     <AssemblyOriginatorKeyFile>../../Persimmon.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />

--- a/src/Persimmon/Persimmon.fsproj
+++ b/src/Persimmon/Persimmon.fsproj
@@ -7,6 +7,7 @@
     <AssemblyOriginatorKeyFile>../../Persimmon.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
+	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />


### PR DESCRIPTION
AssemblyInfoの自動生成がデフォルトで有効になっており、リリースされているアセンブリのファイルバージョンが`1.0.0.0`になってしまっていました。
修正してAssemblyInfo.fsの内容が反映されるようにしました。

https://docs.microsoft.com/ja-jp/dotnet/core/project-sdk/msbuild-props#generateassemblyinfo